### PR TITLE
Change CurlException to Exception

### DIFF
--- a/src/Services/VatlayerService.php
+++ b/src/Services/VatlayerService.php
@@ -92,7 +92,7 @@ class VatlayerService
         $curlError = curl_error($this->curlHandler);
         $curlErrorNr = curl_errno($this->curlHandler);
         if ($curlError !== '') {
-            throw new \CurlException(vsprintf('Connection error number `%s`: `%s`.', [$curlErrorNr, $curlError]));
+            throw new \Exception(vsprintf('Connection error number `%s`: `%s`.', [$curlErrorNr, $curlError]));
         }
 
         // Parse the response as JSON, will be null if not parsable JSON.


### PR DESCRIPTION
CurlException used to be part of Guzzle but isn't anymore and this works just as fine;

![image](https://user-images.githubusercontent.com/431360/126459381-bf679d7b-597f-4346-a38c-e059732bf374.png)
